### PR TITLE
Fix mis-use of LJ_CUTOFF_CHECK

### DIFF
--- a/src/gromacs/mdlib/nbnxn_cuda/nbnxn_cuda_kernels.cuh
+++ b/src/gromacs/mdlib/nbnxn_cuda/nbnxn_cuda_kernels.cuh
@@ -157,7 +157,7 @@
 /* Analytical Ewald interaction kernels with twin-range cut-off
  */
 #define EL_EWALD_ANA
-#define LJ_CUTOFF_CHECK
+#define VDW_CUTOFF_CHECK
 
 /* cut-off + V shift LJ */
 #define NB_KERNEL_FUNC_NAME(x, ...) x ## _ElecEwTwinCut_VdwLJ ## __VA_ARGS__
@@ -189,7 +189,7 @@
 #undef NB_KERNEL_FUNC_NAME
 
 #undef EL_EWALD_ANA
-#undef LJ_CUTOFF_CHECK
+#undef VDW_CUTOFF_CHECK
 
 
 /* Tabulated Ewald interaction kernels */
@@ -229,7 +229,7 @@
 
 /* Tabulated Ewald interaction kernels with twin-range cut-off */
 #define EL_EWALD_TAB
-#define LJ_CUTOFF_CHECK
+#define VDW_CUTOFF_CHECK
 
 /* cut-off + V shift LJ */
 #define NB_KERNEL_FUNC_NAME(x, ...) x ## _ElecEwQSTabTwinCut_VdwLJ ## __VA_ARGS__
@@ -261,4 +261,4 @@
 #undef NB_KERNEL_FUNC_NAME
 
 #undef EL_EWALD_TAB
-#undef LJ_CUTOFF_CHECK
+#undef VDW_CUTOFF_CHECK

--- a/src/gromacs/mdlib/nbnxn_ocl/nbnxn_ocl_kernels.clh
+++ b/src/gromacs/mdlib/nbnxn_ocl/nbnxn_ocl_kernels.clh
@@ -170,7 +170,7 @@
 /* Analytical Ewald interaction kernels with twin-range cut-off
  */
 #define EL_EWALD_ANA
-#define LJ_CUTOFF_CHECK
+#define VDW_CUTOFF_CHECK
 
 /* cut-off + V shift LJ */
 #define NB_KERNEL_FUNC_NAME(x, y) x ## _ElecEwTwinCut_VdwLJ ## y
@@ -202,7 +202,7 @@
 #undef NB_KERNEL_FUNC_NAME
 
 #undef EL_EWALD_ANA
-#undef LJ_CUTOFF_CHECK
+#undef VDW_CUTOFF_CHECK
 
 
 /* Tabulated Ewald interaction kernels */
@@ -242,7 +242,7 @@
 
 /* Tabulated Ewald interaction kernels with twin-range cut-off */
 #define EL_EWALD_TAB
-#define LJ_CUTOFF_CHECK
+#define VDW_CUTOFF_CHECK
 
 /* cut-off + V shift LJ */
 #define NB_KERNEL_FUNC_NAME(x, y) x ## _ElecEwQSTabTwinCut_VdwLJ ## y
@@ -274,6 +274,6 @@
 #undef NB_KERNEL_FUNC_NAME
 
 #undef EL_EWALD_TAB
-#undef LJ_CUTOFF_CHECK
+#undef VDW_CUTOFF_CHECK
 
 #undef CL_SOURCE_FILE


### PR DESCRIPTION
This applies the same kind of fix as implemented in 8e974b0eb5bc in
gromacs/master, which was found and fixed after the SC fork.

If there's need to reproduce this fix on other branches, use something
like:

sed -i -e 's/LJ_CUTOFF_CHECK/VDW_CUTOFF_CHECK/g' \
    $(git ls-files src)
